### PR TITLE
Enable GDAL exceptions

### DIFF
--- a/tdm/radar/utils.py
+++ b/tdm/radar/utils.py
@@ -6,6 +6,8 @@ import numpy as np
 import gdal
 from gdal import osr
 
+gdal.UseExceptions()
+
 
 def get_grid(fname, unit='km', send_raster=False):
     "extract grid information from a geo image"

--- a/tdm/wrf/projector.py
+++ b/tdm/wrf/projector.py
@@ -1,4 +1,7 @@
+import gdal
 from gdal import ogr, osr
+
+gdal.UseExceptions()
 
 
 def project(transform, p):


### PR DESCRIPTION
By default, GDAL does not raise exceptions. They have to be explicitly enabled, and that's what this PR does.