### PR TITLE
Docker update

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.travis.yml
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN echo 'APT::Get::Assume-Yes "true";' >> /etc/apt/apt.conf.d/99yes && \
       libudunits2-dev \
       netcdf-bin \
       python3-dev \
-      python3-numpy \
       python3-pip \
       wget && \
     apt-get clean && \
@@ -30,10 +29,11 @@ RUN wget ${cdourl} && \
     cd .. && \
     rm -rf ${cdosrc}*
 
-RUN CFLAGS="$(gdal-config --cflags)" pip install --no-cache-dir \
-    gdal==$(gdal-config --version)
-
-RUN pip install --no-cache-dir Cython && \
+RUN pip install --no-cache-dir \
+        Cython \
+	numpy && \
+    CFLAGS="$(gdal-config --cflags)" pip install --no-cache-dir \
+        gdal==$(gdal-config --version) && \
     pip install --no-cache-dir \
         cdo \
         cf-units \


### PR DESCRIPTION
* Add `.dockerignore`
* Install NumPy from pip, so we get the latest version

The main difference is that NumPy from apt is built around system blas/lapack/fortran, whereas a plain `pip install numpy` results in extension modules linking to built-in libs in `numpy/.libs`. I'm not sure if there's any significant difference in performance. This is more consistent since we are installing scipy with pip anyway.

If at any point we end up needing bleeding edge performance we might consider other build/install methods for the whole "scientific" stack.