### PR TITLE
grib2cf updates

### DIFF
--- a/bin/tdm_grib2cf
+++ b/bin/tdm_grib2cf
@@ -7,31 +7,45 @@ NetCDF Climate and Forecast (CF) Metadata Conventions
 """
 
 import argparse
-import glob
+import os
 import sys
 
 import cdo
 
 
+def get_gribs(args):
+    gribs = []
+    for name in os.listdir(args.input):
+        if not name.endswith(".grib2"):
+            continue
+        if args.model not in name:
+            continue
+        if args.start not in name:
+            continue
+        gribs.append(os.path.join(args.input, name))
+    return gribs
+
+
 def main(args):
-    glob_path = "{}/{}_{}_*".format(args.input_dir,
-                                    args.product_type,
-                                    args.start_time)
-    gribs = sorted(glob.glob(glob_path))
+    gribs = get_gribs(args)
+    print("'%s': %d files" % (args.input, len(gribs)))
+    if not gribs:
+        sys.exit("no files selected, aborting")
+    tag = args.out_tag or os.path.basename(args.input)
+    out_fn = os.path.join(args.output, "%s.nc" % tag)
     c = cdo.Cdo()
-    ofile = "{}/{}_{}.nc".format(args.output_dir,
-                                 args.product_type,
-                                 args.start_time)
-    c.cat(input=' '.join(gribs), output=ofile,
-          options='-r -f nc')
+    try:
+        os.makedirs(args.output)
+    except FileExistsError:
+        pass
+    c.cat(input=' '.join(gribs), output=out_fn, options='-r -f nc')
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('product_type', metavar="PRODUCT_TYPE")
-    parser.add_argument('start_time', metavar="START_TIME")
-    parser.add_argument('-d', '--input-dir', metavar="INPUT_DIR",
-                        default=".")
-    parser.add_argument('-O', '--output-dir', metavar="OUTPUT_DIR",
-                        default=".")
+    parser.add_argument('-i', '--input', metavar="DIR", default=".")
+    parser.add_argument('-o', '--output', metavar="DIR", default=".")
+    parser.add_argument('-t', '--out-tag', metavar="STRING")
+    parser.add_argument('--model', metavar="STRING", default="")
+    parser.add_argument('--start', metavar="STRING", default="")
     main(parser.parse_args(sys.argv[1:]))

--- a/test/sim/scripts/run
+++ b/test/sim/scripts/run
@@ -11,7 +11,7 @@ wd=$(mktemp -d)
 netcdf_dir="${wd}/netcdf"
 mkdir -p "${netcdf_dir}"
 
-tdm_grib2cf -d "${data}" -O "${netcdf_dir}" bolam 2018071300
+tdm_grib2cf -i "${data}" -o "${netcdf_dir}"
 nc_ds=$(find "${netcdf_dir}" -name '*.nc' | head -n 1)
 "${tools}"/check_sim_nc "${netcdf_dir}"
 


### PR DESCRIPTION
Makes filtering by model / start_time optional, so that user can opt to convert whole dir contents