### PR TITLE
Grib2 tool and base Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .git
 .travis.yml
 Dockerfile
+docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,5 @@
-FROM ubuntu:18.04
+FROM crs4/tdm-base:latest
 MAINTAINER simone.leo@crs4.it
-
-RUN echo 'APT::Get::Assume-Yes "true";' >> /etc/apt/apt.conf.d/99yes && \
-    apt update && \
-    apt upgrade && \
-    apt install \
-      gdal-bin \
-      libeccodes-dev \
-      libgdal-dev \
-      libudunits2-dev \
-      netcdf-bin \
-      python3-dev \
-      python3-pip \
-      wget && \
-    apt-get clean && \
-    ln -rs /usr/bin/python3 /usr/bin/python && \
-    ln -rs /usr/bin/pip3 /usr/bin/pip
-
-# `apt-get install cdo` installs hundreds of packages
-ENV cdosite https://code.mpimet.mpg.de//attachments/download/18264
-ENV cdosrc cdo-1.9.5
-ENV cdourl ${cdosite}/${cdosrc}.tar.gz
-RUN wget ${cdourl} && \
-    tar xf ${cdosrc}.tar.gz && \
-    cd ${cdosrc} && \
-    ./configure --with-netcdf --with-eccodes --with-grib_api && \
-    make -j$(grep -c ^processor /proc/cpuinfo); make install && \
-    cd .. && \
-    rm -rf ${cdosrc}*
 
 RUN pip install --no-cache-dir \
         Cython \

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,0 +1,29 @@
+FROM ubuntu:18.04
+MAINTAINER simone.leo@crs4.it
+
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+
+RUN echo 'APT::Get::Assume-Yes "true";' >> /etc/apt/apt.conf.d/99yes && \
+    apt update && \
+    apt upgrade && \
+    apt install \
+      gdal-bin \
+      gfortran \
+      libeccodes-dev \
+      libgdal-dev \
+      libudunits2-dev \
+      m4 \
+      netcdf-bin \
+      python3-dev \
+      python3-pip \
+      wget && \
+    apt-get clean && \
+    ln -rs /usr/bin/python3 /usr/bin/python && \
+    ln -rs /usr/bin/pip3 /usr/bin/pip
+
+COPY scripts /scripts
+
+RUN bash /scripts/install_cdo.sh && \
+    bash /scripts/install_wgrib2.sh && \
+    rm -rf /scripts

--- a/docker/build
+++ b/docker/build
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+this="${BASH_SOURCE-$0}"
+this_dir=$(cd -P -- "$(dirname -- "${this}")" && pwd -P)
+
+pushd "${this_dir}"
+docker build -t crs4/tdm-base -f Dockerfile.base .
+popd

--- a/docker/scripts/install_cdo.sh
+++ b/docker/scripts/install_cdo.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# `apt-get install cdo` installs hundreds of packages
+
+set -euo pipefail
+
+cdosite=https://code.mpimet.mpg.de//attachments/download/18264
+cdosrc=cdo-1.9.5
+cdourl=${cdosite}/${cdosrc}.tar.gz
+wd=$(mktemp -d)
+
+pushd "${wd}"
+wget ${cdourl}
+tar xf ${cdosrc}.tar.gz
+pushd ${cdosrc}
+./configure --with-netcdf --with-eccodes --with-grib_api
+make -j$(grep -c ^processor /proc/cpuinfo)
+make install
+popd
+popd
+
+rm -rf "${wd}"

--- a/docker/scripts/install_wgrib2.sh
+++ b/docker/scripts/install_wgrib2.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir_name=grib2
+tar_name=wgrib2.tgz
+url=ftp://ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/${tar_name}
+wd=$(mktemp -d)
+
+pushd "${wd}"
+wget ${url}
+tar xf ${tar_name}
+pushd ${dir_name}
+sed -i -e 's|^USE_NETCDF3=1|USE_NETCDF3=0|' makefile
+sed -i -e 's|^USE_NETCDF4=0|USE_NETCDF4=1|' makefile
+sed -i -e 's|check install|install|g' makefile
+netcdf4_tar_name=$(grep -m 1 'netcdf4src=' makefile | cut -d '=' -f 2)
+netcdf4_url=ftp://ftp.unidata.ucar.edu/pub/netcdf/"${netcdf4_tar_name}"
+hdf5_tar_name=$(grep -m 1 'hdf5src:=' makefile | cut -d '=' -f 2)
+hdf5_version=$(echo ${hdf5_tar_name} | cut -d '-' -f 2 | cut -d '.' -f 1-3)
+hdf5_maj_min=$(echo ${hdf5_version} | cut -d '.' -f 1-2)
+hdf5_url=https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${hdf5_maj_min}/hdf5-${hdf5_version}/src/hdf5-${hdf5_version}.tar.gz
+wget "${netcdf4_url}"
+tar xf "${netcdf4_tar_name}"
+wget "${hdf5_url}"
+tar xf "${hdf5_tar_name}"
+FC=gfortran CC=gcc make
+install wgrib2/wgrib2 /usr/local/bin
+popd
+popd
+
+rm -rf "${wd}"


### PR DESCRIPTION
Adds `wgrib2`. At this point it takes too long to build everything on the fly, so I've moved APT dependencies plus `cdo` and `wgrib2` (which should change less frequently than pip deps and our own stuff) to a base Docker container. The idea is to rebuild the base container (and push it to Docker Hub) only when strictly necessary.
