### PR TITLE
CKAN indexing: set name attributes to short descriptions

### DIFF
--- a/tools/ckan_desc_map.json
+++ b/tools/ckan_desc_map.json
@@ -1,10 +1,22 @@
 {
-    "meteosim": "weather forecast simulation",
-    "bolam": "BOLAM model",
-    "moloch": "MOLOCH model",
-    "netcdf": "rotated pole coordinates",
-    "netcdf-lonlat": "lat-lon coordinates",
-    "radar": "radar rainfall",
-    "1m": "one set of values per minute",
-    "1h": "average values over 1h windows"
+    "short": {
+	"meteosim": "simulation",
+	"bolam": "bolam",
+	"moloch": "moloch",
+	"netcdf": "rotatedpole",
+	"netcdf-lonlat": "latlon",
+	"radar": "radar",
+	"1m": "1m",
+	"1h": "1h"
+    },
+    "long": {
+	"meteosim": "weather forecast simulation",
+	"bolam": "BOLAM model",
+	"moloch": "MOLOCH model",
+	"netcdf": "rotated pole coordinates",
+	"netcdf-lonlat": "lat-lon coordinates",
+	"radar": "radar rainfall",
+	"1m": "one set of values per minute",
+	"1h": "average values over 1h windows"
+    }
 }

--- a/tools/ckan_desc_map_it.json
+++ b/tools/ckan_desc_map_it.json
@@ -1,0 +1,22 @@
+{
+    "short": {
+	"meteosim": "simulation",
+	"bolam": "bolam",
+	"moloch": "moloch",
+	"netcdf": "rotatedpole",
+	"netcdf-lonlat": "latlon",
+	"radar": "radar",
+	"1m": "1m",
+	"1h": "1h"
+    },
+    "long": {
+	"meteosim": "simulazione meteo",
+	"bolam": "modello BOLAM",
+	"moloch": "modello MOLOCH",
+	"netcdf": "coordinate rotated pole",
+	"netcdf-lonlat": "coordinate lat-lon",
+	"radar": "intensita' piovosa, radar Cagliari",
+	"1m": "valori al minuto",
+	"1h": "valori mediati su intervalli di 1h"
+    }
+}

--- a/tools/gen_ckan_idx.py
+++ b/tools/gen_ckan_idx.py
@@ -73,7 +73,8 @@ def dump_event_map(m):
 
 def main(args):
     with io.open(args.desc_map, "rt", encoding="utf-8") as f:
-        desc_map = json.load(f)
+        temp = json.load(f)
+        short_desc_map, desc_map = temp["short"], temp["long"]
     try:
         os.makedirs(args.out_dir)
     except FileExistsError:
@@ -96,7 +97,11 @@ def main(args):
                         url = re.sub(f"^{args.in_dir}", args.base_url, ds.path)
                         resources.append({
                             "url": url,
-                            "name": ds.name,
+                            "name": "_".join([
+                                "bulk",
+                                short_desc_map[src],
+                                short_desc_map[proc_id.name]
+                            ]),
                             "format": "netcdf",
                             "description": " - ".join([
                                 desc_map[src],
@@ -111,7 +116,12 @@ def main(args):
                             )
                             resources.append({
                                 "url": url,
-                                "name": ds.name,
+                                "name": "_".join([
+                                    "bulk",
+                                    short_desc_map[src],
+                                    short_desc_map[proc_id.name],
+                                    short_desc_map[proj.name],
+                                ]),
                                 "format": "netcdf",
                                 "description": " - ".join([
                                     desc_map[src],
@@ -130,7 +140,12 @@ def main(args):
                     )
                     resources.append({
                         "url": url,
-                        "name": "description.json",
+                        "name": "_".join([
+                            "ra",
+                            short_desc_map[src],
+                            short_desc_map[proc_id],
+                            "latlon",
+                        ]),
                         "format": "json",
                         "description": " - ".join([
                             desc_map[src],
@@ -147,7 +162,12 @@ def main(args):
                     )
                     resources.append({
                         "url": url,
-                        "name": "description.json",
+                        "name": "_".join([
+                            "ra",
+                            short_desc_map[src],
+                            short_desc_map[entry.name],
+                            "latlon",
+                        ]),
                         "format": "json",
                         "description": " - ".join([
                             desc_map[src],

--- a/tools/gen_ckan_idx.py
+++ b/tools/gen_ckan_idx.py
@@ -191,5 +191,4 @@ if __name__ == "__main__":
     parser.add_argument("-i", "--in-dir", metavar="DIR", default=os.getcwd())
     parser.add_argument("-o", "--out-dir", metavar="DIR",
                         default=join(os.getcwd(), "ckan_upload"))
-    parser.add_argument("--overwrite", action="store_true")
     main(parser.parse_args(sys.argv[1:]))


### PR DESCRIPTION
In the previous version we simply set the `"name"` resource attributes to file basenames, which does not help CKAN search and results in several different resources having the same `"description.json"` name.